### PR TITLE
Add CLI agent for debt repair document generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# codex
+# Debt/Credit Repair Agent
+
+## Quick start
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python agent.py make-calendar
+python agent.py filings
+python agent.py letters
+```
+
+Outputs land in `out/`. Edit `data/plan.yaml` to change dates, addresses, and amounts.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,181 @@
+import os, datetime as dt, pytz
+import click
+from ruamel.yaml import YAML
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from docx import Document
+from ics import Calendar, Event
+
+yaml = YAML()
+
+def load(yaml_path):
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        return yaml.load(f)
+
+def jenv():
+    return Environment(
+        loader=FileSystemLoader("templates"),
+        autoescape=select_autoescape()
+    )
+
+def write_docx(text, outpath):
+    doc = Document()
+    for para in text.split("\n"):
+        doc.add_paragraph(para)
+    os.makedirs(os.path.dirname(outpath), exist_ok=True)
+    doc.save(outpath)
+
+def fmt_money(x): return f"{x:,.2f}"
+
+def compute_amount(balance, pct):
+    return round(balance * pct / 100.0, 2)
+
+@click.group()
+def cli():
+    """Debt/Credit Repair Agent"""
+
+@cli.command()
+@click.option("--cfg", default="data/plan.yaml")
+def make_calendar(cfg):
+    """Emit .ics with your deadlines."""
+    plan = load(cfg)
+    tz = pytz.timezone(plan["tz"])
+    cal = Calendar()
+    def add(uid, date_str, title):
+        d = tz.localize(dt.datetime.strptime(date_str, "%Y-%m-%d"))
+        ev = Event(name=title, begin=d, duration=dt.timedelta(hours=1))
+        ev.uid = uid
+        cal.events.add(ev)
+    dd = plan["deadlines"]
+    add("opp_msj", dd["oppose_msj"], "File Opposition to MSJ + Motion to Strike")
+    add("mov_623", dd["mov_bureaus_623"], "Mail §611 MOV to EQ/TU/EX + §623 to Chase")
+    add("fdcpas", dd["fdcpas"], "Mail FDCPA validations to SCS and Credit Collections")
+    add("rebuild", dd["rebuild_day45"], "Day 45: Rebuild wave kickoff")
+    out = os.path.join(plan["out_dir"], "deadlines.ics")
+    os.makedirs(plan["out_dir"], exist_ok=True)
+    with open(out, "w", encoding="utf-8") as f: f.writelines(cal.serialize_iter())
+    click.echo(out)
+
+@cli.command()
+@click.option("--cfg", default="data/plan.yaml")
+def filings(cfg):
+    """Generate court filings for Chase 4155."""
+    plan = load(cfg); env = jenv()
+    now = dt.datetime.now().strftime("%Y-%m-%d")
+    ctx = {**plan, "now": now}
+
+    # Opposition
+    text = env.get_template("opposition_msj.j2").render(**ctx)
+    fn = f'{plan["court"]["cause_no"]}_Opposition_to_MSJ.docx'
+    write_docx(text, os.path.join(plan["out_dir"], fn))
+
+    # Motion to Strike
+    text = env.get_template("motion_strike_affidavit.j2").render(**ctx)
+    fn = f'{plan["court"]["cause_no"]}_Motion_to_Strike_Affidavit.docx'
+    write_docx(text, os.path.join(plan["out_dir"], fn))
+
+    # Hardship declaration
+    text = env.get_template("hardship_declaration.j2").render(**ctx)
+    fn = "Hardship_Declaration.docx"
+    write_docx(text, os.path.join(plan["out_dir"], fn))
+
+    click.echo("filings OK")
+
+@cli.command()
+@click.option("--cfg", default="data/plan.yaml")
+def letters(cfg):
+    """Generate all dispute and settlement letters."""
+    plan = load(cfg); env = jenv()
+    today = dt.datetime.now().strftime("%Y-%m-%d")
+    party = plan["party"]; facts = plan["facts"]
+
+    out_dir = plan["out_dir"]; os.makedirs(out_dir, exist_ok=True)
+
+    # Settlement – Chase 4155
+    for i, pct in enumerate(plan["offers"]["chase_4155"], start=1):
+        ctx = {
+            **plan, "date": today, "name": "Chase 4155",
+            "balance": fmt_money(facts["chase_balance_4155"]),
+            "pct": pct, "amount": fmt_money(compute_amount(facts["chase_balance_4155"], pct)),
+            "to_address": plan["mailing"]["plaintiff_counsel"], "wave": i
+        }
+        text = env.get_template("settlement_offer.j2").render(**ctx)
+        fn = f"Chase_4155_Wave{i}_Settlement_Offer_{today}.docx"
+        write_docx(text, os.path.join(out_dir, fn))
+
+    # §611 MOV to bureaus (duplicate JPMCB *4978)
+    mov = env.get_template("frca_611_mov.j2").render(**plan, date=today)
+    for bureau in plan["mailing"]["bureaus"]:
+        fn = f'Bureaus_§611_MOV_JPMCB4978_{today}_{bureau.split(",")[0].replace(" ", "")}.docx'
+        write_docx(mov, os.path.join(out_dir, fn))
+
+    # §623 direct dispute to Chase
+    text = env.get_template("frca_623_direct.j2").render(**plan, date=today)
+    fn = f"Chase_§623_DirectDispute_DuplicateTradeline_{today}.docx"
+    write_docx(text, os.path.join(out_dir, fn))
+
+    # FDCPA validations + PFD ladders
+    # SCS (ComEd)
+    for i, pct in enumerate(plan["offers"]["scs_comed"], start=1):
+        ctx = {
+            **plan, "date": today, "pct": pct,
+            "amount": fmt_money(compute_amount(facts["scs_comed_balance"], pct))
+        }
+        text = env.get_template("fdCPA_1692g_pfd.j2").render(**ctx)
+        fn = f"SCS_ComEd_Validation_PFD_{today}_Wave{i}.docx"
+        write_docx(text, os.path.join(out_dir, fn))
+
+    # Credit Collections (Progressive)
+    for i, pct in enumerate(plan["offers"]["credit_collections_prog"], start=1):
+        ctx = {
+            **plan, "date": today, "pct": pct,
+            "amount": fmt_money(compute_amount(facts["credit_collections_prog_balance"], pct))
+        }
+        text = env.get_template("fdCPA_1692g_pfd.j2").render(**ctx)
+        fn = f"CreditCollections_Progressive_Validation_PFD_{today}_Wave{i}.docx"
+        write_docx(text, os.path.join(out_dir, fn))
+
+    # AmEx + BofA offers
+    for name, bal_key, ladder in [
+        ("Amex_15443", "amex_balance", plan["offers"]["amex"]),
+        ("BofA", "bofa_balance", plan["offers"]["bofa"])
+    ]:
+        for i, pct in enumerate(ladder, start=1):
+            ctx = {
+                **plan, "date": today, "name": name,
+                "balance": fmt_money(facts[bal_key]),
+                "pct": pct, "amount": fmt_money(compute_amount(facts[bal_key], pct)),
+                "to_address": "[Creditor address here]", "wave": i
+            }
+            text = env.get_template("settlement_offer.j2").render(**ctx)
+            fn = f"{name}_Wave{i}_Settlement_Offer_{today}.docx"
+            write_docx(text, os.path.join(out_dir, fn))
+
+    click.echo("letters OK")
+
+@cli.command()
+@click.option("--cfg", default="data/plan.yaml")
+def scaffold(cfg):
+    """Create out/ filenames exactly as specified in your brief."""
+    plan = load(cfg)
+    out = plan["out_dir"]; os.makedirs(out, exist_ok=True)
+    court = plan["court"]["cause_no"]
+    today = dt.datetime.now().strftime("%Y-%m-%d")
+    targets = [
+        f"{court}_Opposition_to_MSJ.docx",
+        f"{court}_Motion_to_Strike_Affidavit.docx",
+        f"Chase_4155_Wave1_Settlement_Offer_{today}.docx",
+        f"Bureaus_§611_MOV_JPMCB4978_{today}.docx",
+        f"Chase_§623_DirectDispute_DuplicateTradeline_{today}.docx",
+        f"SCS_ComEd_Validation_PFD_{today}.docx",
+        f"CreditCollections_Validation_PFD_Progressive_{today}.docx",
+        f"Amex_15443_Wave1_Settlement_Offer_{today}.docx",
+        f"BofA_Itemization_and_Settlement_Wave1_{today}.docx",
+    ]
+    for t in targets:
+        p = os.path.join(out, t)
+        if not os.path.exists(p):
+            Document().save(p)
+    click.echo("scaffold OK")
+
+if __name__ == "__main__":
+    cli()

--- a/data/plan.yaml
+++ b/data/plan.yaml
@@ -1,0 +1,62 @@
+tz: America/Chicago
+
+# DUE DATES (YYYY-MM-DD)
+deadlines:
+  oppose_msj: 2025-10-09
+  mov_bureaus_623: 2025-10-10
+  fdcpas: 2025-10-13
+  rebuild_day45: 2025-11-22
+
+# CASE + COURT
+court:
+  cause_no: "45D03-2504-CC-003807"
+  court_name: "Lake Superior Court, Civil Division 3"
+  jurisdiction: "Lake County, Indiana"
+  efile_service_for_plaintiff: "Blitt & Gaines, P.C., 775 Corporate Woods Pkwy, Vernon Hills, IL 60061"
+
+party:
+  defendant_name: "Alyssa C. Heeter"
+  defendant_addr: "[Your PO Box / safe address]"
+  email: "[optional]"
+  phone: "[optional]"
+
+# FACTS used in filings (pulled from your reports/pleadings)
+facts:
+  chase_balance_4155: 7774.65
+  chase_last_payment_memo: {date: "2024-08-16", amount: 226.00}   # Memo says 8/16/24 $226
+  chase_last_payment_affidavit: {date: "2024-05-16", amount: 230.00} # Affidavit says 5/16/24 $230
+  jpmcb_4978_balance: 2754
+  jpmcb_4978_dofd: "2024-07-19"
+  jpmcb_4978_cl: 2300
+  jpmcb_4978_high: 13065
+  chase_4155_cl: 6300
+  amex_balance: 3013
+  bofa_balance: 6653
+  scs_comed_balance: 3477
+  credit_collections_prog_balance: 119
+  nordstrom_td_open: true
+
+# ADDRESSES
+mailing:
+  plaintiff_counsel: "Blitt & Gaines, P.C., 775 Corporate Woods Pkwy, Vernon Hills, IL 60061"
+  chase_furnisher: "JPMorgan Chase Bank, N.A., PO Box 15369, Wilmington, DE 19850"
+  bureaus:
+    - "Equifax, PO Box 740241, Atlanta, GA 30374"
+    - "TransUnion, PO Box 2000, Chester, PA 19016"
+    - "Experian, PO Box 4500, Allen, TX 75013"
+  scs:
+    - "Southwest Credit Systems, 4120 International Pkwy, Carrollton, TX 75007"
+  credit_collections:
+    - "Credit Collection Services, 725 Canton St, Norwood, MA 02062"
+
+# OFFER LADDERS (percent)
+offers:
+  chase_4155: [30, 37, 45]
+  jpmcb_4978: [20, 30, 40]
+  amex: [25, 33, 45]
+  bofa: [20, 30, 42]
+  scs_comed: [25, 35, 45]
+  credit_collections_prog: [50, 100]
+
+# OUTPUT DIR
+out_dir: "out"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+click==8.1.7
+python-docx==1.1.2
+jinja2==3.1.4
+ics==0.7.2
+pytz==2024.1
+ruamel.yaml==0.18.6

--- a/templates/fdCPA_1692g_pfd.j2
+++ b/templates/fdCPA_1692g_pfd.j2
@@ -1,4 +1,31 @@
-Re: Validation Request under 15 U.S.C. §1692g and Pay-for-Delete Negotiation
+{{ party.defendant_name }}
+{{ party.defendant_addr }}
+{% if party.email and party.email != "[optional]" %}Email: {{ party.email }}
+{% endif %}{% if party.phone and party.phone != "[optional]" %}Phone: {{ party.phone }}
+{% endif %}
+{{ date }}
 
-Please provide: (1) original contract/authority, (2) full itemization, (3) proof of assignment, (4) DOFD reported to CRAs, (5) collector license.
-Cease phone contact. Upon validation, I’m prepared to resolve on a written Pay-for-Delete basis at {{ pct }}% (${{ amount }}).
+Via Certified Mail
+{{ to_address }}
+
+Subject: Validation Request & Pay-for-Delete Negotiation – {{ account_reference }}
+
+Dear Collections Manager:
+
+Pursuant to 15 U.S.C. § 1692g, please provide the following documentation substantiating the alleged
+balance and your authority to collect: (1) the original contract or account-level agreement; (2) a full
+itemization from charge-off through the present; (3) documentation of assignment or ownership; (4) the
+Date of First Delinquency reported to each credit bureau; and (5) proof of any required state collection
+license.
+
+Until validation is complete, please cease telephone communications and limit correspondence to writing.
+Subject to timely validation, I am prepared to resolve this matter on a written pay-for-delete basis at {{ pct }}%
+(${{ amount }}). The agreement must include deletion of the tradeline from all credit reporting agencies
+within 30 days of confirmed payment.
+
+Please acknowledge receipt of this request within 30 days and confirm the address for remitting any agreed
+payment. I appreciate your cooperation in resolving this matter professionally.
+
+Sincerely,
+
+{{ party.defendant_name }}

--- a/templates/fdCPA_1692g_pfd.j2
+++ b/templates/fdCPA_1692g_pfd.j2
@@ -1,0 +1,4 @@
+Re: Validation Request under 15 U.S.C. §1692g and Pay-for-Delete Negotiation
+
+Please provide: (1) original contract/authority, (2) full itemization, (3) proof of assignment, (4) DOFD reported to CRAs, (5) collector license.
+Cease phone contact. Upon validation, I’m prepared to resolve on a written Pay-for-Delete basis at {{ pct }}% (${{ amount }}).

--- a/templates/frca_611_mov.j2
+++ b/templates/frca_611_mov.j2
@@ -1,5 +1,30 @@
-Re: FCRA §611 Dispute & Method of Verification Request – Duplicate/Fragment JPMCB *4978 vs. Chase 4155
+{{ party.defendant_name }}
+{{ party.defendant_addr }}
+{% if party.email and party.email != "[optional]" %}Email: {{ party.email }}
+{% endif %}{% if party.phone and party.phone != "[optional]" %}Phone: {{ party.phone }}
+{% endif %}
+{{ date }}
 
-I dispute JPMCB *4978 as inaccurate/duplicative. *4978 shows CL ${{ facts.jpmcb_4978_cl }}, high ${{ facts.jpmcb_4978_high }},
-DOFD {{ facts.jpmcb_4978_dofd }}, while the Chase/4155 lawsuit reflects a different product with CL ${{ facts.chase_4155_cl }}.
-Delete or consolidate and provide MOV identifying the furnisher, contact, and specific records relied upon.
+Via Certified Mail
+{{ to_address }}
+
+Subject: FCRA §611 Dispute & Method of Verification Request – JPMCB *4978 vs. Chase 4155
+
+Dear Disputes Department:
+
+I am formally disputing the accuracy of the JPMCB *4978 tradeline reporting on my credit file. The entry
+shows a credit limit of ${{ fmt_money(facts.jpmcb_4978_cl) }}, a high balance of ${{ fmt_money(facts.jpmcb_4978_high) }}, and a Date of
+First Delinquency of {{ facts.jpmcb_4978_dofd }}. These details are inconsistent with the Chase 4155 account that
+is the subject of current litigation (credit limit ${{ fmt_money(facts.chase_4155_cl) }}), indicating the tradeline may be a
+duplicate or fragment of the same obligation.
+
+Please conduct a reasonable reinvestigation, delete or consolidate any duplicative reporting, and provide
+a detailed Method of Verification. The MOV should identify the furnisher, the individual or department
+contacted, and the specific account records relied upon for verification.
+
+I appreciate your prompt attention to this dispute and request a written response within the 30-day
+statutory period. Please mail your findings to the address above.
+
+Sincerely,
+
+{{ party.defendant_name }}

--- a/templates/frca_611_mov.j2
+++ b/templates/frca_611_mov.j2
@@ -1,0 +1,5 @@
+Re: FCRA §611 Dispute & Method of Verification Request – Duplicate/Fragment JPMCB *4978 vs. Chase 4155
+
+I dispute JPMCB *4978 as inaccurate/duplicative. *4978 shows CL ${{ facts.jpmcb_4978_cl }}, high ${{ facts.jpmcb_4978_high }},
+DOFD {{ facts.jpmcb_4978_dofd }}, while the Chase/4155 lawsuit reflects a different product with CL ${{ facts.chase_4155_cl }}.
+Delete or consolidate and provide MOV identifying the furnisher, contact, and specific records relied upon.

--- a/templates/frca_623_direct.j2
+++ b/templates/frca_623_direct.j2
@@ -1,0 +1,3 @@
+Re: Direct Dispute under FCRA §623 – Reconcile / Delete Duplicative Tradeline
+
+Identify the correct tradeline (4155 vs. *4978). If 4155 is the live account of record, delete *4978 and correct limits/high credit/DOFD.

--- a/templates/frca_623_direct.j2
+++ b/templates/frca_623_direct.j2
@@ -1,3 +1,28 @@
-Re: Direct Dispute under FCRA §623 – Reconcile / Delete Duplicative Tradeline
+{{ party.defendant_name }}
+{{ party.defendant_addr }}
+{% if party.email and party.email != "[optional]" %}Email: {{ party.email }}
+{% endif %}{% if party.phone and party.phone != "[optional]" %}Phone: {{ party.phone }}
+{% endif %}
+{{ date }}
 
-Identify the correct tradeline (4155 vs. *4978). If 4155 is the live account of record, delete *4978 and correct limits/high credit/DOFD.
+Via Certified Mail
+{{ to_address }}
+
+Subject: Direct Dispute under FCRA §623 – Reconcile / Delete Duplicative Tradeline
+
+To the Chase Executive Office:
+
+I am submitting a direct dispute regarding conflicting tradeline data associated with my Chase account
+ending *4155 and a separate JPMCB tradeline ending *4978. Please identify the accurate live account of
+record and reconcile the reporting so only one complete and accurate tradeline remains.
+
+If the *4155 account is the operative record, please delete the *4978 tradeline and update all limits, high
+balances, and Date of First Delinquency values accordingly. Kindly provide written confirmation of the steps
+taken and the records reviewed in resolving this dispute.
+
+Thank you for your attention to this matter. I look forward to your written confirmation within the
+statutory timeframe.
+
+Sincerely,
+
+{{ party.defendant_name }}

--- a/templates/hardship_declaration.j2
+++ b/templates/hardship_declaration.j2
@@ -1,0 +1,4 @@
+Brief Declaration of Hardship
+
+I experienced job loss (Feb 2024), caregiving for a parent with cancer, and unexpected housing remediation costs (Sept 2025).
+This declaration is submitted solely to explain current inability to pay in full and to support reasonable settlement.

--- a/templates/hardship_declaration.j2
+++ b/templates/hardship_declaration.j2
@@ -1,4 +1,26 @@
-Brief Declaration of Hardship
+{{ party.defendant_name }}
+{{ party.defendant_addr }}
+{% if party.email and party.email != "[optional]" %}Email: {{ party.email }}
+{% endif %}{% if party.phone and party.phone != "[optional]" %}Phone: {{ party.phone }}
+{% endif %}
 
-I experienced job loss (Feb 2024), caregiving for a parent with cancer, and unexpected housing remediation costs (Sept 2025).
-This declaration is submitted solely to explain current inability to pay in full and to support reasonable settlement.
+Brief Declaration of Financial Hardship
+
+I, {{ party.defendant_name }}, submit this declaration to summarize the circumstances impacting my current
+ability to pay outstanding consumer obligations in full. In February 2024, I experienced a job loss that
+significantly reduced household income. Since that time, I have taken on primary caregiving responsibilities
+for a parent undergoing cancer treatment, which has further limited my availability to work and required
+additional out-of-pocket expenses.
+
+In September 2025, I also faced unexpected housing remediation costs to address urgent health and safety
+issues. These combined events depleted emergency reserves and left me with limited disposable income.
+
+This declaration is provided in good faith to document my hardship, support reasonable settlement
+discussions, and explain why I am unable to offer more than the structured settlement percentages included
+with my correspondence. I certify that the statements above are true and correct to the best of my
+knowledge.
+
+Dated: {{ now if now is defined else date }}
+
+____________________________________
+{{ party.defendant_name }}

--- a/templates/motion_strike_affidavit.j2
+++ b/templates/motion_strike_affidavit.j2
@@ -1,6 +1,37 @@
-… MOTION TO STRIKE OR DISREGARD AFFIDAVIT PORTIONS …
+IN THE {{ court.jurisdiction|upper }} {{ court.court_name|upper }}
+CAUSE NO. {{ court.cause_no }}
 
-Grounds: (1) internal contradiction on last-payment date/amount; (2) hearsay and lack of proper foundation for business
-records; (3) no itemization of fees/interest from charge-off to present; (4) absence of complete monthly statements.
+JPMORGAN CHASE BANK, N.A.                )
+      Plaintiff,                          )
+v.                                        )
+{{ party.defendant_name|upper }},         )
+      Defendant.                          )
 
-Relief: strike contradictory paragraphs; disregard balance assertions lacking itemization; order production of pp. 1–49 statements.
+DEFENDANT’S MOTION TO STRIKE OR DISREGARD AFFIDAVIT PORTIONS
+
+Defendant {{ party.defendant_name }} moves the Court, pursuant to Trial Rule 56(E) and the Rules of Evidence, to
+strike or disregard the deficient portions of Plaintiff’s affidavit and supporting designations.
+
+1. Internal Contradiction. The affidavit conflicts with Plaintiff’s own memorandum regarding the alleged last
+   payment, swearing to ${{ fmt_money(facts.chase_last_payment_affidavit.amount) }} on {{ facts.chase_last_payment_affidavit.date }} while the
+   memorandum asserts ${{ fmt_money(facts.chase_last_payment_memo.amount) }} on {{ facts.chase_last_payment_memo.date }}. The contradiction
+   renders the affiant’s testimony unreliable.
+
+2. Hearsay and Lack of Foundation. The affiant offers business-record conclusions without laying the
+   requisite foundation or attaching the referenced records. Trial Rule 56(E) requires personal knowledge and
+   admissible evidence, which are lacking here.
+
+3. Missing Itemization and Statements. The affidavit references “Periodic Billing Statements (pp. 1–49)” yet
+   fails to attach the full statements or itemize the balance from charge-off to present. Without complete
+   records, the balance testimony is conclusory.
+
+Relief Requested. Defendant requests that the Court strike the contradictory paragraphs, disregard any balance
+assertions lacking itemization or foundation, and order production of the complete page 1–49 statement set
+prior to any renewed dispositive motion.
+
+Dated: {{ now }}
+
+Respectfully submitted,
+
+{{ party.defendant_name }}
+{{ party.defendant_addr }}

--- a/templates/motion_strike_affidavit.j2
+++ b/templates/motion_strike_affidavit.j2
@@ -1,0 +1,6 @@
+… MOTION TO STRIKE OR DISREGARD AFFIDAVIT PORTIONS …
+
+Grounds: (1) internal contradiction on last-payment date/amount; (2) hearsay and lack of proper foundation for business
+records; (3) no itemization of fees/interest from charge-off to present; (4) absence of complete monthly statements.
+
+Relief: strike contradictory paragraphs; disregard balance assertions lacking itemization; order production of pp. 1–49 statements.

--- a/templates/opposition_msj.j2
+++ b/templates/opposition_msj.j2
@@ -1,0 +1,24 @@
+IN THE {{ court.jurisdiction|upper }} {{ court.court_name|upper }}
+CAUSE NO. {{ court.cause_no }}
+
+JPMORGAN CHASE BANK, N.A.                )
+      Plaintiff,                          )
+v.                                        )
+{{ party.defendant_name|upper }},         )
+      Defendant.                          )
+
+DEFENDANT’S OPPOSITION TO PLAINTIFF’S MOTION FOR SUMMARY JUDGMENT
+
+Defendant opposes Summary Judgment. A genuine dispute of material fact exists because
+Plaintiff’s own designated materials conflict on the “last payment” (Memo asserts ${{ facts.chase_last_payment_memo.amount }}
+on {{ facts.chase_last_payment_memo.date }}; Affidavit swears ${{ facts.chase_last_payment_affidavit.amount }} on {{ facts.chase_last_payment_affidavit.date }}),
+defeating account-stated as a matter of law. Plaintiff also failed to itemize the balance and to produce the full run of
+statements despite designating “Periodic Billing Statements (pp. 1–49).”
+
+Requested relief: deny Summary Judgment; alternatively, defer under Rule 56 to compel complete statements and
+itemization; set for trial.
+
+Dated: {{ now }}
+
+{{ party.defendant_name }}
+{{ party.defendant_addr }}

--- a/templates/opposition_msj.j2
+++ b/templates/opposition_msj.j2
@@ -9,16 +9,26 @@ v.                                        )
 
 DEFENDANT’S OPPOSITION TO PLAINTIFF’S MOTION FOR SUMMARY JUDGMENT
 
-Defendant opposes Summary Judgment. A genuine dispute of material fact exists because
-Plaintiff’s own designated materials conflict on the “last payment” (Memo asserts ${{ facts.chase_last_payment_memo.amount }}
-on {{ facts.chase_last_payment_memo.date }}; Affidavit swears ${{ facts.chase_last_payment_affidavit.amount }} on {{ facts.chase_last_payment_affidavit.date }}),
-defeating account-stated as a matter of law. Plaintiff also failed to itemize the balance and to produce the full run of
-statements despite designating “Periodic Billing Statements (pp. 1–49).”
+Defendant {{ party.defendant_name }} respectfully submits this memorandum in opposition to Plaintiff’s Motion for
+Summary Judgment. Genuine disputes of material fact and procedural defects require denial of the motion.
 
-Requested relief: deny Summary Judgment; alternatively, defer under Rule 56 to compel complete statements and
-itemization; set for trial.
+1. Conflicting Evidence on the Alleged “Last Payment.” Plaintiff’s own designated materials conflict on the
+   purported last payment, creating a dispute for trial. The Plaintiff’s Memo asserts a ${{ fmt_money(facts.chase_last_payment_memo.amount) }}
+   payment on {{ facts.chase_last_payment_memo.date }}, while the supporting affidavit swears the last payment
+   was ${{ fmt_money(facts.chase_last_payment_affidavit.amount) }} on {{ facts.chase_last_payment_affidavit.date }}. These contradictions
+   defeat the account-stated theory as a matter of law and preclude summary judgment.
+
+2. Absence of Itemization and Complete Statements. Plaintiff fails to itemize the balance or provide the full run
+   of periodic statements despite designating “Periodic Billing Statements (pp. 1–49).” Without a complete
+   accounting, the Court cannot assess the claimed balance or the legality of fees and interest.
+
+Requested Relief. Defendant asks the Court to deny the Motion for Summary Judgment. In the alternative,
+Defendant requests that the Court defer ruling under Trial Rule 56 to compel production of the complete
+statements and a detailed itemization, and to set the matter for trial following supplementation.
 
 Dated: {{ now }}
+
+Respectfully submitted,
 
 {{ party.defendant_name }}
 {{ party.defendant_addr }}

--- a/templates/settlement_offer.j2
+++ b/templates/settlement_offer.j2
@@ -1,15 +1,35 @@
-{{ date }} 
+{{ party.defendant_name }}
+{{ party.defendant_addr }}
+{% if party.email and party.email != "[optional]" %}Email: {{ party.email }}
+{% endif %}{% if party.phone and party.phone != "[optional]" %}Phone: {{ party.phone }}
+{% endif %}
+{{ date }}
 
-Via Email & Certified Mail
+Via Certified Mail & Email
 {{ to_address }}
 
-Re: Settlement Offer (No admission) – {{ name }} – Balance ${{ balance }}
+Subject: Settlement Proposal – {{ name }} (Balance ${{ balance }})
 
-Wave-{{ wave }} offer: {{ pct }}% = ${{ amount }} lump-sum for (i) dismissal with prejudice (if in suit), 
-(ii) each side bears fees/costs, (iii) no post–charge-off interest or fees, (iv) furnish “settled” within 30 days,
-(v) no resale of remainder; written agreement required before any payment.
+Dear Counsel:
 
-Hardship summary attached.
+I appreciate your attention to the pending {{ name }} matter. I am writing to propose an amicable
+resolution that acknowledges the documented financial hardship I am experiencing while allowing both
+parties to avoid continued litigation risk and expense.
+
+For Wave {{ wave }}, I can tender {{ pct }}% of the outstanding balance, which equals ${{ amount }}, as a
+single lump-sum payment. Acceptance of this offer is contingent upon the following standard terms:
+
+1. Full dismissal with prejudice (where litigation is pending) and mutual release of claims.
+2. Each party bears its own attorney fees, costs, and expenses.
+3. No post–charge-off interest, late fees, or other add-ons will be pursued or reported.
+4. The account will be reported to all credit bureaus as “settled in full” within 30 days of payment.
+5. The remaining balance will not be sold, reassigned, or collected by any third party.
+
+Please confirm acceptance in writing so we may finalize a settlement agreement and payment logistics.
+For ease of review, I have attached my hardship declaration outlining the circumstances driving this proposal.
+
+Thank you for your consideration. I look forward to resolving this matter cooperatively.
 
 Sincerely,
+
 {{ party.defendant_name }}

--- a/templates/settlement_offer.j2
+++ b/templates/settlement_offer.j2
@@ -1,0 +1,15 @@
+{{ date }} 
+
+Via Email & Certified Mail
+{{ to_address }}
+
+Re: Settlement Offer (No admission) – {{ name }} – Balance ${{ balance }}
+
+Wave-{{ wave }} offer: {{ pct }}% = ${{ amount }} lump-sum for (i) dismissal with prejudice (if in suit), 
+(ii) each side bears fees/costs, (iii) no post–charge-off interest or fees, (iv) furnish “settled” within 30 days,
+(v) no resale of remainder; written agreement required before any payment.
+
+Hardship summary attached.
+
+Sincerely,
+{{ party.defendant_name }}


### PR DESCRIPTION
## Summary
- add a configurable CLI agent that renders court filings, dispute letters, and calendar entries from Jinja templates
- provide YAML plan data and prebuilt templates to drive document generation and naming
- document setup steps and pin Python dependencies for the automation

## Testing
- python -m compileall agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ad2ecd708322bc29e3ea49e6d6d3